### PR TITLE
リポジトリの一部メソッドを削除

### DIFF
--- a/src/main/java/com/twtwtwgj/todolist/repository/ToDoRepository.java
+++ b/src/main/java/com/twtwtwgj/todolist/repository/ToDoRepository.java
@@ -8,9 +8,5 @@ import java.util.List;
 
 @Repository
 public interface ToDoRepository extends JpaRepository<ToDo, Integer> {
-    @Override
-    public List<ToDo> findAll();
 
-    @Override
-    public ToDo save(ToDo toDo);
 }


### PR DESCRIPTION
JpaRepositoryにすでに存在するメソッドをわざわざこちらで記述する必要はなかった
（ここで表示せずともControllerクラスで使用することが出来る）